### PR TITLE
Add Yosys elaboration support

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -35,3 +35,7 @@ sources:
   - src/clic_apb.sv
   - src/clic.sv
 
+  - target: clic_synth_test
+    files:
+      - src/clic_synth_pkg.sv
+      - src/clic_synth_wrap.sv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+ROOT := $(shell pwd)
+
+include yosys/yosys.mk

--- a/src/clic_synth_pkg.sv
+++ b/src/clic_synth_pkg.sv
@@ -1,0 +1,29 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SPDX-License-Identifier: Apache-2.0
+
+`include "register_interface/typedef.svh"
+
+package clic_synth_pkg;
+
+  localparam int N_SOURCE   = 256;
+  localparam int SRC_W      = $clog2(N_SOURCE);
+  localparam int INTCTLBITS = 8;
+  localparam bit SSCLIC     = 1;
+  localparam bit USCLIC     = 0;
+
+  `REG_BUS_TYPEDEF_ALL(reg, logic [31:0], logic [31:0], logic [3:0])
+
+endpackage

--- a/src/clic_synth_wrap.sv
+++ b/src/clic_synth_wrap.sv
@@ -1,0 +1,58 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SPDX-License-Identifier: Apache-2.0
+
+module clic_synth_wrap
+  import clic_synth_pkg::*;
+(
+  input  logic                     clk_i,
+  input  logic                     rst_ni,
+  input  reg_req_t                 reg_req_i,
+  output reg_rsp_t                 reg_rsp_o,
+  input  logic      [N_SOURCE-1:0] intr_src_i,
+  output logic                     irq_valid_o,
+  input  logic                     irq_ready_i,
+  output logic         [SRC_W-1:0] irq_id_o,
+  output logic               [7:0] irq_level_o,
+  output logic                     irq_shv_o,
+  output logic               [1:0] irq_priv_o,
+  output logic                     irq_kill_req_o,
+  input  logic                     irq_kill_ack_i
+);
+
+  clic #(
+    .reg_req_t  ( reg_req_t  ),
+    .reg_rsp_t  ( reg_rsp_t  ),
+    .N_SOURCE   ( N_SOURCE   ),
+    .INTCTLBITS ( INTCTLBITS ),
+    .SSCLIC     ( SSCLIC     ),
+    .USCLIC     ( USCLIC     )
+  ) i_clic (
+    .clk_i          ( clk_i          ),
+    .rst_ni         ( rst_ni         ),
+    .reg_req_i      ( reg_req_i      ),
+    .reg_rsp_o      ( reg_rsp_o      ),
+    .intr_src_i     ( intr_src_i     ),
+    .irq_valid_o    ( irq_valid_o    ),
+    .irq_ready_i    ( irq_ready_i    ),
+    .irq_id_o       ( irq_id_o       ),
+    .irq_level_o    ( irq_level_o    ),
+    .irq_shv_o      ( irq_shv_o      ),
+    .irq_priv_o     ( irq_priv_o     ),
+    .irq_kill_req_o ( irq_kill_req_o ),
+    .irq_kill_ack_i ( irq_kill_ack_i )
+  );
+
+endmodule

--- a/yosys/.gitignore
+++ b/yosys/.gitignore
@@ -1,0 +1,3 @@
+out/
+reports/
+*.flist

--- a/yosys/elaborate.tcl
+++ b/yosys/elaborate.tcl
@@ -1,0 +1,32 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+set top_design clic_synth_wrap
+
+yosys plugin -i slang.so
+
+yosys read_slang --top ${top_design} -F clic.flist \
+    --compat-mode --keep-hierarchy \
+    --allow-use-before-declare --ignore-unknown-modules \
+    --ignore-assertions -Wno-error=duplicate-definition
+
+yosys hierarchy -top ${top_design}
+yosys check
+
+yosys tee -q -o "reports/clic_elaborated.rpt" stat
+yosys write_verilog -norename -noexpr -attr2comment out/clic_elaborated.v
+
+exit

--- a/yosys/yosys.mk
+++ b/yosys/yosys.mk
@@ -1,0 +1,37 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+
+BENDER ?= bender
+YOSYS  ?= oseda -2025.03 yosys
+
+YOSYS_ROOT_DIR    ?= $(ROOT)/yosys
+YOSYS_OUT_DIR     := $(YOSYS_ROOT_DIR)/out
+YOSYS_REPORTS_DIR := $(YOSYS_ROOT_DIR)/reports
+
+$(YOSYS_ROOT_DIR)/clic.flist: Bender.yml
+	$(BENDER) script flist-plus -t rtl -t synthesis -t asic -t clic_synth_test > $@
+
+$(YOSYS_OUT_DIR)/clic_elaborated.v: $(YOSYS_ROOT_DIR)/clic.flist
+	mkdir -p $(YOSYS_OUT_DIR) $(YOSYS_REPORTS_DIR)
+	cd $(YOSYS_ROOT_DIR) && $(YOSYS) -C elaborate.tcl
+
+.PHONY: yosys-elaborate
+yosys-elaborate: $(YOSYS_OUT_DIR)/clic_elaborated.v
+	@echo "Synthesized CLIC successfully"
+
+.PHONY: yosys-clean
+yosys-clean:
+	rm -rf $(YOSYS_OUT_DIR) $(YOSYS_REPORTS_DIR) $(YOSYS_ROOT_DIR)/clic.flist


### PR DESCRIPTION
This PR adds support for elaboration with Yosys. At the moment this is basically equivalent to parsing the design with Slang, as Yosys is configured to use Slang to parse the design. However, the idea is that this script could be further extended later on to perform more synthesis steps or even full synthesis in an open-source technology such as [IHP-Open-PDK](https://github.com/IHP-GmbH/IHP-Open-PDK).